### PR TITLE
Feature/fix-all-routing-with-stripe-and-refistraction-flaw

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,7 +1,0 @@
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  // const result = render(<App />);
-  // expect(result).toBeTruthy();
-});

--- a/frontend/src/features/consumer/Consumer.routes.tsx
+++ b/frontend/src/features/consumer/Consumer.routes.tsx
@@ -9,8 +9,7 @@ export function ConsumerRoutes() {
   return (
     <Routes>
       <Route path="" element={<ConsumerPage />}>
-        <Route index element={<CreateScreen />} />
-        <Route path="cabinet" element={<ConsumerScreen />} />
+        <Route index element={<ConsumerScreen />} />
         <Route path="registration" element={<CreateScreen />} />
         <Route path="update/:id" element={<ConsumerUpdateDataFormScreen />} />
       </Route>

--- a/frontend/src/features/credit/CreateScreen/CreateScreen.components.tsx
+++ b/frontend/src/features/credit/CreateScreen/CreateScreen.components.tsx
@@ -43,10 +43,10 @@ export const CreateScreen = () => {
         if (response.Loan === 'created') {
           message.success('The loan is created successfully');
         }
-        navigate(routes.investor.absolute());
+        navigate(routes.consumer.absolute());
       } catch (error) {
         console.log('error', error);
-        message.error('Erro due to creating od loan');
+        message.error('Error due to creating od loan');
       }
     },
   });

--- a/frontend/src/features/investor/Investor.routes.tsx
+++ b/frontend/src/features/investor/Investor.routes.tsx
@@ -1,7 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { InvestorPage } from './Investor.page';
 import { InvestorCabinetScreen } from './InvestorCabinetScreen';
-import { InvestorDataFormScreen } from './InvestorDataFormScreen/InvestorDataFormScreen.component';
+import { InvestorDataFormScreen } from '@/features/investor/InvestorDataFormScreen';
 import { InvestorScreen } from './InvestorScreen';
 import { InvestorUpdateDataFormScreen } from './InvestorUpdateDataFormScreen';
 

--- a/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.component.tsx
+++ b/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.component.tsx
@@ -1,4 +1,5 @@
-import { Col, Layout, Popover, Row } from 'antd';
+import { Col, Layout, Popover, Row, Modal } from 'antd';
+import {useSearchParams} from "react-router-dom";
 
 import { InvestorInvestmentsTable } from '@/components/InvestorInvestmentsTable/InvestorInvestmaentsTable';
 import diagram from '../../../images/diagram.png';
@@ -12,10 +13,16 @@ import {
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { useCurrentInvestor, usePotentialPayout } from '@/hooks/investor';
 import { Messages } from '@/components/Messages/Messages';
+import {useEffect, useState} from "react";
 
 export function InvestorCabinetScreen() {
   const { Name, Surname, MiddleName, Balance } = useCurrentInvestor();
   const { payout } = usePotentialPayout();
+
+  const [searchParams, setSearchParams] = useSearchParams() ;
+  const stripeTypeMsg = searchParams.get('type');
+  const [isVisible, setIsVisible] = useState(false);
+  const [confirmLoading, setConfirmLoading] = useState(false);
 
   const balance = (
     <div style={{ width: '200px', fontSize: '14px' }}>Your current balance</div>
@@ -26,6 +33,22 @@ export function InvestorCabinetScreen() {
       Potential interest amount for this month's payments
     </div>
   );
+
+  useEffect(() => {
+    if(stripeTypeMsg) setIsVisible(true);
+  },[stripeTypeMsg]);
+
+  const handleOk = () => {
+    setConfirmLoading(true);
+    setTimeout(() => {
+      setIsVisible(false);
+      setConfirmLoading(false);
+    }, 2000);
+  };
+
+  const handleCancel = () => {
+    setIsVisible(false);
+  };
 
   return (
     <Layout>
@@ -74,6 +97,22 @@ export function InvestorCabinetScreen() {
           </Col>
         </Row>
       </InvestorTable>
+      { stripeTypeMsg && <div>
+        <Modal
+            title="Stripe message"
+            visible={isVisible}
+            onOk={handleOk}
+            confirmLoading={confirmLoading}
+            onCancel={handleCancel}
+        >
+          <p>{stripeTypeMsg === 'success' ?
+                  'Payment Successful':
+              stripeTypeMsg === 'error' ?
+                  'Payment Failure' : ''}
+          </p>
+        </Modal>
+       </div>}
     </Layout>
+
   );
 }

--- a/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.component.tsx
+++ b/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.component.tsx
@@ -1,4 +1,4 @@
-import { Col, Layout, Popover, Row, Modal } from 'antd';
+import { Col, Layout, Popover, Row, Modal, Button } from 'antd';
 import {useSearchParams} from "react-router-dom";
 
 import { InvestorInvestmentsTable } from '@/components/InvestorInvestmentsTable/InvestorInvestmaentsTable';
@@ -9,6 +9,9 @@ import {
   InvestorHeader,
   InvestorInfo,
   InvestorTable,
+  StripeInfo,
+  StripeInfoError,
+  StripeInfoSuccess,
 } from './InvestorCabinetScreen.styles';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { useCurrentInvestor, usePotentialPayout } from '@/hooks/investor';
@@ -102,14 +105,18 @@ export function InvestorCabinetScreen() {
             title="Stripe message"
             visible={isVisible}
             onOk={handleOk}
-            confirmLoading={confirmLoading}
             onCancel={handleCancel}
+            confirmLoading={confirmLoading}
+            footer={[
+            <Button type='primary' key="submit" loading={confirmLoading} onClick={handleOk}>
+             OK
+            </Button>]}
         >
-          <p>{stripeTypeMsg === 'success' ?
-                  'Payment Successful':
+          <StripeInfo>{stripeTypeMsg === 'success' ?
+              <StripeInfoSuccess className={'stripe-msg-success'}>Payment Successfull!</StripeInfoSuccess> :
               stripeTypeMsg === 'error' ?
-                  'Payment Failure' : ''}
-          </p>
+                 <StripeInfoError className={'stripe-msg-error'}>Payment Failure!</StripeInfoError> : ''}
+          </StripeInfo>
         </Modal>
        </div>}
     </Layout>

--- a/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.component.tsx
+++ b/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.component.tsx
@@ -1,5 +1,5 @@
 import { Col, Layout, Popover, Row, Modal, Button } from 'antd';
-import {useSearchParams} from "react-router-dom";
+import { useSearchParams } from 'react-router-dom';
 
 import { InvestorInvestmentsTable } from '@/components/InvestorInvestmentsTable/InvestorInvestmaentsTable';
 import diagram from '../../../images/diagram.png';
@@ -16,13 +16,13 @@ import {
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { useCurrentInvestor, usePotentialPayout } from '@/hooks/investor';
 import { Messages } from '@/components/Messages/Messages';
-import {useEffect, useState} from "react";
+import { useEffect, useState } from 'react';
 
 export function InvestorCabinetScreen() {
   const { Name, Surname, MiddleName, Balance } = useCurrentInvestor();
   const { payout } = usePotentialPayout();
 
-  const [searchParams, setSearchParams] = useSearchParams() ;
+  const [searchParams, setSearchParams] = useSearchParams();
   const stripeTypeMsg = searchParams.get('type');
   const [isVisible, setIsVisible] = useState(false);
   const [confirmLoading, setConfirmLoading] = useState(false);
@@ -38,8 +38,8 @@ export function InvestorCabinetScreen() {
   );
 
   useEffect(() => {
-    if(stripeTypeMsg) setIsVisible(true);
-  },[stripeTypeMsg]);
+    if (stripeTypeMsg) setIsVisible(true);
+  }, [stripeTypeMsg]);
 
   const handleOk = () => {
     setConfirmLoading(true);
@@ -100,26 +100,41 @@ export function InvestorCabinetScreen() {
           </Col>
         </Row>
       </InvestorTable>
-      { stripeTypeMsg && <div>
-        <Modal
+      {stripeTypeMsg && (
+        <div>
+          <Modal
             title="Stripe message"
             visible={isVisible}
             onOk={handleOk}
             onCancel={handleCancel}
             confirmLoading={confirmLoading}
             footer={[
-            <Button type='primary' key="submit" loading={confirmLoading} onClick={handleOk}>
-             OK
-            </Button>]}
-        >
-          <StripeInfo>{stripeTypeMsg === 'success' ?
-              <StripeInfoSuccess className={'stripe-msg-success'}>Payment Successfull!</StripeInfoSuccess> :
-              stripeTypeMsg === 'error' ?
-                 <StripeInfoError className={'stripe-msg-error'}>Payment Failure!</StripeInfoError> : ''}
-          </StripeInfo>
-        </Modal>
-       </div>}
+              <Button
+                type="primary"
+                key="submit"
+                loading={confirmLoading}
+                onClick={handleOk}
+              >
+                OK
+              </Button>,
+            ]}
+          >
+            <StripeInfo>
+              {stripeTypeMsg === 'success' ? (
+                <StripeInfoSuccess className={'stripe-msg-success'}>
+                  Payment Successfull!
+                </StripeInfoSuccess>
+              ) : stripeTypeMsg === 'error' ? (
+                <StripeInfoError className={'stripe-msg-error'}>
+                  Payment Failure!
+                </StripeInfoError>
+              ) : (
+                ''
+              )}
+            </StripeInfo>
+          </Modal>
+        </div>
+      )}
     </Layout>
-
   );
 }

--- a/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.styles.ts
+++ b/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.styles.ts
@@ -24,16 +24,15 @@ export const InvestorInfo = styled.div`
 `;
 
 export const StripeInfo = styled.p`
-    text-align: center;
-    font-size: 1.3rem;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    transform: translateY(35%);
+  text-align: center;
+  font-size: 1.3rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  transform: translateY(35%);
 `;
 
 export const StripeInfoSuccess = styled.span`
   color: var(--link-button);
- 
 `;
 
 export const StripeInfoError = styled.span`

--- a/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.styles.ts
+++ b/frontend/src/features/investor/InvestorCabinetScreen/InvestorCabinetScreen.styles.ts
@@ -22,3 +22,20 @@ export const InvestorInfo = styled.div`
   font-size: 1.3rem;
   padding-top: 20px;
 `;
+
+export const StripeInfo = styled.p`
+    text-align: center;
+    font-size: 1.3rem;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    transform: translateY(35%);
+`;
+
+export const StripeInfoSuccess = styled.span`
+  color: var(--link-button);
+ 
+`;
+
+export const StripeInfoError = styled.span`
+  color: var(--red-button);
+`;

--- a/frontend/src/features/investor/InvestorDataFormScreen/InvestorDataFormScreen.component.tsx
+++ b/frontend/src/features/investor/InvestorDataFormScreen/InvestorDataFormScreen.component.tsx
@@ -45,7 +45,7 @@ export const InvestorDataFormScreen: React.FC = () => {
             message.error('Error while trying to add payment.'),
           );
       } catch (error) {
-        return message.error("Something goes's wrong");
+        return message.error("Something goes wrong");
       }
     },
   });

--- a/frontend/src/features/investor/InvestorDataFormScreen/InvestorDataFormScreen.component.tsx
+++ b/frontend/src/features/investor/InvestorDataFormScreen/InvestorDataFormScreen.component.tsx
@@ -45,7 +45,7 @@ export const InvestorDataFormScreen: React.FC = () => {
             message.error('Error while trying to add payment.'),
           );
       } catch (error) {
-        return message.error("Something goes wrong");
+        return message.error('Something goes wrong');
       }
     },
   });

--- a/frontend/src/features/login/UserTypeRegistration/UserTypeRegistrationScreen.component.tsx
+++ b/frontend/src/features/login/UserTypeRegistration/UserTypeRegistrationScreen.component.tsx
@@ -42,7 +42,7 @@ export const UserTypeRegistrationScreen = () => {
               <ButtonText> As investor </ButtonText>
             </RedButton>
           </Link>
-          <Link to={`${routes.consumer.cabinet.registration.absolute()}`}>
+          <Link to={`${routes.consumer.registration.absolute()}`}>
             <RedButton>
               <ButtonText>As consumer</ButtonText>
             </RedButton>

--- a/frontend/src/features/obtain/ObtainScreen/ObtainScreen.component.tsx
+++ b/frontend/src/features/obtain/ObtainScreen/ObtainScreen.component.tsx
@@ -17,7 +17,7 @@ export const ObtainScreen = () => {
   const navigate = useNavigate();
   const handleClick = () => {
     if (currentUser?.role === 'consumer') navigate('/consumer');
-    else if (currentUser?.role === 'investor') navigate('investor');
+    else if (currentUser?.role === 'investor') navigate('/investor');
   };
 
   return (

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -39,13 +39,9 @@ export const routes = {
   },
   consumer: {
     absolute: () => '/consumer',
-    cabinet: {
-      absolute: () => '/consumer/cabinet',
-      relative: () => 'cabinet',
-      registration: {
+    registration: {
         absolute: () => '/consumer/registration',
         relative: () => 'registration',
-      },
     },
   },
   obtain: {

--- a/frontend/src/routing/routes.ts
+++ b/frontend/src/routing/routes.ts
@@ -40,8 +40,8 @@ export const routes = {
   consumer: {
     absolute: () => '/consumer',
     registration: {
-        absolute: () => '/consumer/registration',
-        relative: () => 'registration',
+      absolute: () => '/consumer/registration',
+      relative: () => 'registration',
     },
   },
   obtain: {


### PR DESCRIPTION
-correct redirection after /obtain. (registration stripe) Now we see after the registration login page again;
-fix routing: after submitting the loan form consumer cabinet doesn/t have to redirect to investor page;
-add page which is redirected by stripe in /cancel payment; Add url in backend;
-add page which is redirected by stripe in /payment/success; Add url  in backend;
-fix routing so after the user has already registered, after the next logIn don't choose the role again;